### PR TITLE
downstreams provide vectorclock time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ compile:
 
 clean:
 	$(REBAR) clean
+	rm -r _build/default/rel/antidote/antidote* || true
 
 distclean: clean relclean
 	$(REBAR) clean --all

--- a/src/clocksi_downstream.erl
+++ b/src/clocksi_downstream.erl
@@ -62,6 +62,7 @@ generate_downstream_op(Transaction, IndexNode, Key, Type, Update, WriteSet) ->
                 antidote_crdt_counter_b ->
                     %% bcounter data-type.
                     bcounter_mgr:generate_downstream(Key, Update, Snapshot);
+                antidote_crdt_generic -> antidote_crdt_generic:downstream(Update, Snapshot, Transaction#transaction.vec_snapshot_time);
                 _ ->
                     Type:downstream(Update, Snapshot)
             end


### PR DESCRIPTION
Changes the downstream operation to also provide the vectorclock time from the transaction